### PR TITLE
Update README to correctly define plugin import

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ yarn add -D @maginapp/vuepress-plugin-katex
 ```js
 module.exports = {
     // ...
-    plugins: [
-        '@maginapp/vuepress-plugin-katex',
-        {
+    plugins: {
+        '@maginapp/katex': {
           delimiters: 'dollars'
         }
-    ]
+    }
     // ...
 }
 ```


### PR DESCRIPTION
The current way of defining the plugins doesn't add them to vuepress correctly. To add options you would either have to wrap the name of the plugin and options in another array or as i've done you can change [plugins to an object](https://v1.vuepress.vuejs.org/plugin/using-a-plugin.html#object-style). 

I also [shortened the plugin import name](https://v1.vuepress.vuejs.org/plugin/using-a-plugin.html#plugin-shorthand) for simplicity